### PR TITLE
fix race condition while fetching current user

### DIFF
--- a/components/CommentSection/index.tsx
+++ b/components/CommentSection/index.tsx
@@ -23,9 +23,7 @@ export default function CommentSection() {
 
     useEffect(() => {
         async function fetchUser() {
-            setIsLoading(true)
             setCurrentUser(await getCurrentUser())
-            setIsLoading(false)
         }
         fetchUser()
     }, [])
@@ -38,6 +36,8 @@ export default function CommentSection() {
         }
         fetchComments()
     }, [commentsDispatch])
+
+    if (!currentUser) return <p>Fazendo login...</p>
 
     return (
         <UserContext.Provider value={currentUser}>


### PR DESCRIPTION
Corrige a issue #3.

O usuário logado e a lista de comentários estavam sendo carregados assincronamente por meio de `useEffect` e, embora o efeito do usuário esteja sendo chamado antes do correspondente à lista de comentários, não há garantia de que o carregamento do usuário termine primeiro.

O problema ocorria porque os dois efeitos estavam usando a mesma variável de estado (`isLoading`) para controlar o estado de carregamento do componente, logo, quando o efeito dos comentários terminava primeiro, ele liberava o componente `CommentsComponent` para ser renderizado, que chamava `useCurrentUser` e retornava erro, já que o efeito do usuário ainda não havia terminado para alimentar o `UserContext`.